### PR TITLE
ignore preflight requests in flask

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -4,18 +4,21 @@ from flask_cors import CORS
 from dotenv import load_dotenv
 # from db import add_tool, get_all_tools
 from db import get_all_tools
-    
+def before_send(event, hint):
+    if event['request']['method'] == 'OPTIONS':
+        return null
+    return event    
 
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
-
 
 sentry_sdk.init(
     dsn="https://2ba68720d38e42079b243c9c5774e05c@sentry.io/1316515",
     traces_sample_rate=1.0,
     integrations=[FlaskIntegration()],
     release=os.environ.get("VERSION"),
-    environment="prod"
+    environment="prod",
+    before_send=before_send
 )
 
 app = Flask(__name__)

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -19,7 +19,9 @@ Sentry.init({
     release: process.env.REACT_APP_RELEASE,
     environment: "prod",
     debug: true,
-    beforeSend(event) {
+    beforeSend(event, hint) {
+      console.log('event', event)
+      console.log('hint', hint)
       if (event.exception) {
         Sentry.showReportDialog();
       }

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -19,7 +19,7 @@ Sentry.init({
     release: process.env.REACT_APP_RELEASE,
     environment: "prod",
     debug: true,
-    beforeSend(event, hint) {
+    beforeSend(event) {
       if (event.exception) {
         Sentry.showReportDialog();
       }

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -20,8 +20,6 @@ Sentry.init({
     environment: "prod",
     debug: true,
     beforeSend(event, hint) {
-      console.log('event', event)
-      console.log('hint', hint)
       if (event.exception) {
         Sentry.showReportDialog();
       }


### PR DESCRIPTION
Now only 1 `get_tools` transaction in Flask for checkout instead of 2:
![image](https://user-images.githubusercontent.com/8920574/78272139-f8ce4800-74c1-11ea-9c5e-c5f9d7a248f2.png)


Dev w/ Docker works:
https://sentry.io/organizations/testorg-az/discover/results/?end=2020-04-03T03%3A59%3A46.500&field=transaction&field=project&field=trace.span&field=transaction.duration&field=timestamp&name=Transactions+with+Trace+ID+4de60162f0294d8a81a46bb763eca150&query=event.type%3Atransaction+trace%3A4de60162f0294d8a81a46bb763eca150&sort=-timestamp&start=2020-04-02T03%3A59%3A42.966&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

Prod GCP works:
https://sentry.io/organizations/testorg-az/discover/results/?end=2020-04-03T04%3A09%3A26.616&field=transaction&field=project&field=trace.span&field=transaction.duration&field=timestamp&name=Transactions+with+Trace+ID+a10716d4c65d40ee9ac682b8c3a0365f&query=event.type%3Atransaction+trace%3Aa10716d4c65d40ee9ac682b8c3a0365f&sort=-timestamp&start=2020-04-02T04%3A09%3A15.559&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1