### PR TITLE
Fix item key ids for data model

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -52,7 +52,7 @@ def process_order(cart):
     global Inventory
     tempInventory = Inventory
     for item in cart:
-        if Inventory[item['type'].encode('utf-8')] <= 0:
+        if Inventory[item['type']] <= 0:
             raise Exception("Not enough inventory for " + item['type'])
         else:
             tempInventory[item['type']] -= 1

--- a/flask/app.py
+++ b/flask/app.py
@@ -52,11 +52,12 @@ def process_order(cart):
     global Inventory
     tempInventory = Inventory
     for item in cart:
-        if Inventory[item['id']] <= 0:
-            raise Exception("Not enough inventory for " + item['id'])
+        item['type'] = item['type'].encode('utf-8')
+        if Inventory[item['type']] <= 0:
+            raise Exception("Not enough inventory for " + item['type'])
         else:
-            tempInventory[item['id']] -= 1
-            print 'Success: ' + item['id'] + ' was purchased, remaining stock is ' + str(tempInventory[item['id']])
+            tempInventory[item['type']] -= 1
+            print 'Success: ' + item['type'] + ' was purchased, remaining stock is ' + str(tempInventory[item['type']])
     Inventory = tempInventory 
 
 @app.before_request

--- a/flask/app.py
+++ b/flask/app.py
@@ -52,8 +52,7 @@ def process_order(cart):
     global Inventory
     tempInventory = Inventory
     for item in cart:
-        item['type'] = item['type'].lower().encode('utf-8')
-        if Inventory[item['type']] <= 0:
+        if Inventory[item['type'].encode('utf-8')] <= 0:
             raise Exception("Not enough inventory for " + item['type'])
         else:
             tempInventory[item['type']] -= 1

--- a/flask/app.py
+++ b/flask/app.py
@@ -52,7 +52,7 @@ def process_order(cart):
     global Inventory
     tempInventory = Inventory
     for item in cart:
-        item['type'] = item['type'].encode('utf-8')
+        item['type'] = item['type'].lower().encode('utf-8')
         if Inventory[item['type']] <= 0:
             raise Exception("Not enough inventory for " + item['type'])
         else:

--- a/react/src/components/App.js
+++ b/react/src/components/App.js
@@ -117,7 +117,7 @@ class App extends Component {
     }).catch((err) => { throw Error(err) });
 
     if (!response.ok) {
-      throw new Error(response.status + " - " + (response.statusText || response.body));
+      throw new Error(response.status + " - " + (response.statusText || "INTERNAL SERVER ERROR"));
     }
 
     this.setState({ success: true });


### PR DESCRIPTION
Data Model itself does not need to be changed. We just need to adapt to it better in our code:

Previously, tools were hard-coded in React and the 'id' was a string like Hammer|Nail|Wrench

Today, we load items from Postgres where the 'id' is a number and the 'type' is Hammer|Nail|Wrench

So update the `process_order` function to look at item's `type` instead of `id` 

`item['type']`