### PR TITLE
Test Data for Performance tracing

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -18,13 +18,16 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 
 KEY = DSN.split('@')[0]
 # remove the 's' in https if sending to localy proxy, or else proxy rejects
-if KEY.index('s') == 4:
-    result = KEY[:4] + KEY[5:]
+try:
+    if KEY.index('s') == 4:
+        KEY = KEY[:4] + KEY[5:]
+except Exception as err:
+    print('DSN key w/ http from self-hosted')
 PROXY = 'localhost:3001'
 MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
 MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
 
-# print('MODIFIED_DSN_SAVE', MODIFIED_DSN_SAVE)
+print('MODIFIED_DSN_SAVE', MODIFIED_DSN_SAVE)
 
 sentry_sdk.init(
     # dsn= DSN or "https://2ba68720d38e42079b243c9c5774e05c@sentry.io/1316515",

--- a/flask/app.py
+++ b/flask/app.py
@@ -16,8 +16,17 @@ def before_send(event, hint):
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 
+KEY = DSN.split('@')[0]
+PROXY = 'localhost:3001'
+MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
+MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
+
+# print('MODIFIED_DSN_SAVE', MODIFIED_DSN_SAVE)
+
 sentry_sdk.init(
-    dsn= DSN or "https://2ba68720d38e42079b243c9c5774e05c@sentry.io/1316515",
+    # dsn= DSN or "https://2ba68720d38e42079b243c9c5774e05c@sentry.io/1316515",
+    # DSN=MODIFIED_DSN_FORWARD,
+    DSN=MODIFIED_DSN_SAVE,
     traces_sample_rate=1.0,
     integrations=[FlaskIntegration()],
     release=os.environ.get("RELEASE"),

--- a/flask/app.py
+++ b/flask/app.py
@@ -17,6 +17,9 @@ import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
 
 KEY = DSN.split('@')[0]
+# remove the 's' in https if sending to localy proxy, or else proxy rejects
+if KEY.index('s') == 4:
+    result = KEY[:4] + KEY[5:]
 PROXY = 'localhost:3001'
 MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
 MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
@@ -26,7 +29,7 @@ MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
 sentry_sdk.init(
     # dsn= DSN or "https://2ba68720d38e42079b243c9c5774e05c@sentry.io/1316515",
     # DSN=MODIFIED_DSN_FORWARD,
-    DSN=MODIFIED_DSN_SAVE,
+    dsn=MODIFIED_DSN_SAVE,
     traces_sample_rate=1.0,
     integrations=[FlaskIntegration()],
     release=os.environ.get("RELEASE"),

--- a/react/src/components/App.js
+++ b/react/src/components/App.js
@@ -78,6 +78,7 @@ class App extends Component {
   }
 
   buyItem(item) {
+    
     this.setState({ success: false });
 
     this.props.addTool(item)
@@ -116,7 +117,7 @@ class App extends Component {
   }
 
   async checkout() {
-    
+
     const order = {
       email: this.email,
       cart: this.props.cart

--- a/react/src/components/App.js
+++ b/react/src/components/App.js
@@ -78,7 +78,7 @@ class App extends Component {
   }
 
   buyItem(item) {
-
+    
     this.setState({ success: false });
 
     this.props.addTool(item)
@@ -117,7 +117,6 @@ class App extends Component {
   }
 
   async checkout() {
-    
     const order = {
       email: this.email,
       cart: this.props.cart

--- a/react/src/components/App.js
+++ b/react/src/components/App.js
@@ -78,7 +78,6 @@ class App extends Component {
   }
 
   buyItem(item) {
-    
     this.setState({ success: false });
 
     this.props.addTool(item)
@@ -117,6 +116,7 @@ class App extends Component {
   }
 
   async checkout() {
+    
     const order = {
       email: this.email,
       cart: this.props.cart

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -19,10 +19,21 @@ const tracingOrigins = [
   process.env.REACT_APP_FRONTEND,
   /^\//
 ]
-console.log('tracingOrigins', tracingOrigins)
+// console.log('tracingOrigins', tracingOrigins)
+
+let DSN = process.env.REACT_APP_DSN
+
+const KEY = DSN.SPLIT('@')[0]
+const PROXY = 'localhost:3001'
+const MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
+const MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
+
+console.log('MODIFIED_DSN_SAVE', MODIFIED_DSN_SAVE)
 
 Sentry.init({
-    dsn: process.env.REACT_APP_DSN || 'https://0d52d5f4e8a64f5ab2edce50d88a7626@sentry.io/1428657',
+    // dsn: process.env.REACT_APP_DSN || 'https://0d52d5f4e8a64f5ab2edce50d88a7626@sentry.io/1428657',
+    // dsn: MODIFIED_DSN_FORWARD,
+    dsn: MODIFIED_DSN_SAVE,
     release: process.env.REACT_APP_RELEASE,
     environment: "prod",
     debug: true,

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -19,21 +19,21 @@ const tracingOrigins = [
   process.env.REACT_APP_FRONTEND,
   /^\//
 ]
-// console.log('tracingOrigins', tracingOrigins)
+console.log('tracingOrigins', tracingOrigins)
 
 let DSN = process.env.REACT_APP_DSN
 
-const KEY = DSN.SPLIT('@')[0]
+// these modified DSN's are for working with test data.
+let KEY = DSN.split('@')[0]
+if (KEY.indexOf('s') === 4) {
+  KEY = KEY.replace('s', '') // http vs https
+}
 const PROXY = 'localhost:3001'
 const MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
 const MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
 
-console.log('MODIFIED_DSN_SAVE', MODIFIED_DSN_SAVE)
-
 Sentry.init({
-    // dsn: process.env.REACT_APP_DSN || 'https://0d52d5f4e8a64f5ab2edce50d88a7626@sentry.io/1428657',
-    // dsn: MODIFIED_DSN_FORWARD,
-    dsn: MODIFIED_DSN_SAVE,
+    dsn: process.env.REACT_APP_DSN || 'https://0d52d5f4e8a64f5ab2edce50d88a7626@sentry.io/1428657',
     release: process.env.REACT_APP_RELEASE,
     environment: "prod",
     debug: true,

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -12,6 +12,15 @@ import { createStore, applyMiddleware } from 'redux'
 import logger from 'redux-logger'
 import rootReducer from './reducers'
 
+// these modified DSN's are for working with test data. You can ignore them.
+let DSN = process.env.REACT_APP_DSN
+let KEY = DSN.split('@')[0]
+if (KEY.indexOf('s') === 4) {
+  KEY = KEY.replace('s', '') // http vs https
+}
+const PROXY = 'localhost:3001'
+const MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
+const MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
 
 const tracingOrigins = [
   'localhost', 
@@ -20,17 +29,6 @@ const tracingOrigins = [
   /^\//
 ]
 console.log('tracingOrigins', tracingOrigins)
-
-let DSN = process.env.REACT_APP_DSN
-
-// these modified DSN's are for working with test data.
-let KEY = DSN.split('@')[0]
-if (KEY.indexOf('s') === 4) {
-  KEY = KEY.replace('s', '') // http vs https
-}
-const PROXY = 'localhost:3001'
-const MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
-const MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
 
 Sentry.init({
     dsn: process.env.REACT_APP_DSN || 'https://0d52d5f4e8a64f5ab2edce50d88a7626@sentry.io/1428657',


### PR DESCRIPTION
# Overview
The following events in Sentry were sent from a custom http transport in `Go`, as opposed to being sent from an SDK. The event (payloads) were originally created by an SDK but then intercepted ("undertaken") by a Proxy and saved in a database, where Go accessed them from. (See https://github.com/thinkocapo/undertaker for the proxy and Go script.)

See on each of these events there is a tag `undertaker:is_here` for tracking them (Discover)

**These changes do not break current workflow**, as I left the default DSN key in place. To actually test this PR you'd have to change this:
```
Sentry.init({
    dsn: process.env.REACT_APP_DSN || 'https://0d52d5f4e8a64f5ab2edce50d88a7626@sentry.io/1428657',
    release: process.env.REACT_APP_RELEASE,
```
to
```
Sentry.init({
    dsn: MODIFIED_DSN_SAVE
    release: process.env.REACT_APP_RELEASE,
```
and do the same where you initialize Sentry in `./flask/app.py`. see the code.

## Python Error + Transaction (flask)
`sentry-demos/tracing/python` (no react involved yet)

#### /handled (endpoint)

py tx
2bd0ef88ab5e45c4b0ddc16a18de86b6 trace ID

py error
2bd0ef88ab5e45c4b0ddc16a18de86b6

#### linked by Trace
trace:2bd0ef88ab5e45c4b0ddc16a18de86b6
https://sentry.io/organizations/testorg-az/discover/results/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&project=5260888&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1


## Checkout Workflow (react<>flask)
`sentry-demos/tracing/react` and it calls `sentry-demos/tracing/python`
#### Pageload

js transaction
a40419e9eebf4d54b6bb3f9153ae362b traceID

py transaction
a40419e9eebf4d54b6bb3f9153ae362b traceID

#### linked by traceID
trace:a40419e9eebf4d54b6bb3f9153ae362b
https://sentry.io/organizations/testorg-az/discover/results/?end=2020-06-16T11%3A26%3A03&field=transaction&field=project&field=trace.span&field=transaction.duration&field=timestamp&name=Transactions+with+Trace+ID+a40419e9eebf4d54b6bb3f9153ae362b&query=event.type%3Atransaction+trace%3Aa40419e9eebf4d54b6bb3f9153ae362b&sort=-timestamp&start=2020-06-15T11%3A25%3A59&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

js error (this.thisCodeBroke())
https://sentry.io/organizations/testorg-az/discover/will-frontend-react:2670ceb5e5f845119b4c6d87f7f8c686/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&project=1428657&project=5260888&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

#### Click Checkout Button

py error ("Not Enough Inventory")
a80bc3960af7412ea60966a53279440a traceID

py tx (/checkout)
a80bc3960af7412ea60966a53279440a traceID

js error ("500 - Internal Server Error")
a80bc3960af7412ea60966a53279440a traceID

js tx (checkout)
a80bc3960af7412ea60966a53279440a traceID

#### transactions linked by traceID
https://sentry.io/organizations/testorg-az/discover/results/?end=2020-06-16T11%3A54%3A28&field=transaction&field=project&field=trace.span&field=transaction.duration&field=timestamp&name=Transactions+with+Trace+ID+a80bc3960af7412ea60966a53279440a&query=event.type%3Atransaction+trace%3Aa80bc3960af7412ea60966a53279440a&sort=-timestamp&start=2020-06-15T11%3A54%3A14&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1

#### 4 THINGS linked by traceID
**2 ERRORS + 2 Transactions, all linked by traceID**
https://sentry.io/organizations/testorg-az/discover/results/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&query=trace%3Aa80bc3960af7412ea60966a53279440a&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1
