### PR TITLE
Randomize the Timeout in Get Tools

### DIFF
--- a/flask/app.py
+++ b/flask/app.py
@@ -7,20 +7,19 @@ from dotenv import load_dotenv
 load_dotenv()
 DSN = os.getenv("FLASK_APP_DSN")
 
-""" use this if sending events to a proxy and not Sentry """
-def testData(DSN):
-    KEY = DSN.split('@')[0]
-    try:
-        if KEY.index('s') == 4: # http vs https
-            KEY = KEY[:4] + KEY[5:]
-    except Exception as err:
-        print('DSN key w/ http from self-hosted')
-    PROXY = 'localhost:3001'
-    # MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
-    MODIFIED_DSN_SAVE = KEY + '@' + "3d19db15b56d.ngrok.io" + '/3'
-    return MODIFIED_DSN_SAVE
-DSN = testData(DSN)
-print("> DSN", DSN)
+# use this if sending test data to a proxy and not Sentry
+# def testData(DSN):
+#     KEY = DSN.split('@')[0]
+#     try:
+#         if KEY.index('https') == 0: # http vs https
+#             KEY = KEY[:4] + KEY[5:]
+#     except Exception as err:
+#         print('DSN key w/ http from self-hosted')
+#     PROXY = 'localhost:3001'
+#     MODIFIED_DSN_SAVE = KEY + '@' + "3d19db15b56d.ngrok.io" + '/3'
+#     return MODIFIED_DSN_SAVE
+# DSN = testData(DSN)
+# print("> DSN", DSN)
 
 def before_send(event, hint):
     if event['request']['method'] == 'OPTIONS':

--- a/flask/app.py
+++ b/flask/app.py
@@ -19,6 +19,9 @@ PROXY = 'localhost:3001'
 MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
 MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
 
+# TODO only use this if you're sending events through a proxy for test data automation
+# DSN = testData(DSN)
+
 def before_send(event, hint):
     if event['request']['method'] == 'OPTIONS':
         return null

--- a/flask/app.py
+++ b/flask/app.py
@@ -11,6 +11,7 @@ DSN = os.getenv("FLASK_APP_DSN")
 # def testData(DSN):
 #     KEY = DSN.split('@')[0]
 #     try:
+#         # only use for local proxy, not proxy served by ngrok
 #         if KEY.index('https') == 0:
 #             KEY = KEY[:4] + KEY[5:]
 #     except Exception as err:

--- a/flask/app.py
+++ b/flask/app.py
@@ -11,11 +11,12 @@ DSN = os.getenv("FLASK_APP_DSN")
 # def testData(DSN):
 #     KEY = DSN.split('@')[0]
 #     try:
-#         if KEY.index('https') == 0: # http vs https
+#         if KEY.index('https') == 0:
 #             KEY = KEY[:4] + KEY[5:]
 #     except Exception as err:
 #         print('DSN key w/ http from self-hosted')
 #     PROXY = 'localhost:3001'
+#     MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
 #     MODIFIED_DSN_SAVE = KEY + '@' + "3d19db15b56d.ngrok.io" + '/3'
 #     return MODIFIED_DSN_SAVE
 # DSN = testData(DSN)

--- a/flask/app.py
+++ b/flask/app.py
@@ -8,19 +8,20 @@ from dotenv import load_dotenv
 load_dotenv()
 DSN = os.getenv("FLASK_APP_DSN")
 
-# these modified DSN's are for working with test data. You can ignore them.
-KEY = DSN.split('@')[0]
-try:
-    if KEY.index('s') == 4: # http vs https
-        KEY = KEY[:4] + KEY[5:]
-except Exception as err:
-    print('DSN key w/ http from self-hosted')
-PROXY = 'localhost:3001'
-MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
-MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
-
-# TODO only use this if you're sending events through a proxy for test data automation
-# DSN = testData(DSN)
+""" use this if sending events to a proxy and not Sentry """
+def testData(DSN):
+    KEY = DSN.split('@')[0]
+    try:
+        if KEY.index('s') == 4: # http vs https
+            KEY = KEY[:4] + KEY[5:]
+    except Exception as err:
+        print('DSN key w/ http from self-hosted')
+    PROXY = 'localhost:3001'
+    MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
+    MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
+    return MODIFIED_DSN_SAVE
+DSN = testData(DSN)
+print("> DSN", MODIFIED_DSN_SAVE)
 
 def before_send(event, hint):
     if event['request']['method'] == 'OPTIONS':

--- a/flask/app.py
+++ b/flask/app.py
@@ -2,7 +2,6 @@ import os
 from flask import Flask, request, json, abort, make_response, jsonify
 from flask_cors import CORS
 from dotenv import load_dotenv
-# from db import add_tool, get_all_tools
 from db import get_all_tools, get_inventory, update_inventory
 from dotenv import load_dotenv
 load_dotenv()
@@ -17,11 +16,11 @@ def testData(DSN):
     except Exception as err:
         print('DSN key w/ http from self-hosted')
     PROXY = 'localhost:3001'
-    MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
-    MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
+    # MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
+    MODIFIED_DSN_SAVE = KEY + '@' + "3d19db15b56d.ngrok.io" + '/3'
     return MODIFIED_DSN_SAVE
 DSN = testData(DSN)
-print("> DSN", MODIFIED_DSN_SAVE)
+print("> DSN", DSN)
 
 def before_send(event, hint):
     if event['request']['method'] == 'OPTIONS':

--- a/flask/db.py
+++ b/flask/db.py
@@ -4,6 +4,8 @@ import psycopg2
 import string
 import psycopg2.extras
 import random
+from random import seed
+from random import randint
 import time
 import sentry_sdk
 from sentry_sdk.integrations.flask import FlaskIntegration
@@ -52,7 +54,12 @@ def get_all_tools():
             conn = db.connect()
         # Execute the query and fetch all results
         with sentry_sdk.start_span(op="run query"):
-            time.sleep(3)
+            # time.sleep(3)
+            # randint(1,6)
+            # numpy.random.lognormal(0.75, .6, 50)
+            number=numpy.random.lognormal(0.75, .6, 50)
+            print("*********** number **********", number)
+            time.sleep(number)
             results = conn.execute(
                 "SELECT * FROM tools"
             ).fetchall()

--- a/flask/db.py
+++ b/flask/db.py
@@ -1,4 +1,5 @@
 import json
+import numpy
 import os
 import psycopg2
 import string
@@ -54,12 +55,7 @@ def get_all_tools():
             conn = db.connect()
         # Execute the query and fetch all results
         with sentry_sdk.start_span(op="run query"):
-            # time.sleep(3)
-            # randint(1,6)
-            # numpy.random.lognormal(0.75, .6, 50)
-            number=numpy.random.lognormal(0.75, .6, 50)
-            print("*********** number **********", number)
-            time.sleep(number)
+            time.sleep(numpy.random.lognormal(0.75, .6, 1)[0])
             results = conn.execute(
                 "SELECT * FROM tools"
             ).fetchall()

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -3,6 +3,7 @@ sentry-sdk==0.14.2
 flask-cors==3.0.7
 gunicorn==0.14.2
 blinker==1.4
+numpy==1.19.0
 psycopg2-binary==2.8.4
 python-dotenv==0.12.0
 sqlalchemy==1.3.15

--- a/flask/requirements.txt
+++ b/flask/requirements.txt
@@ -3,7 +3,7 @@ sentry-sdk==0.14.2
 flask-cors==3.0.7
 gunicorn==0.14.2
 blinker==1.4
-numpy==1.19.0
+numpy==1.16.6
 psycopg2-binary==2.8.4
 python-dotenv==0.12.0
 sqlalchemy==1.3.15

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -21,6 +21,8 @@ if (KEY.indexOf('s') === 4) {
 const PROXY = 'localhost:3001'
 const MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
 const MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
+// TODO only use this if you're sending events through a proxy for test data automation
+// DSN = testData(DSN)
 
 const tracingOrigins = [
   'localhost', 

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -12,17 +12,19 @@ import { createStore, applyMiddleware } from 'redux'
 import logger from 'redux-logger'
 import rootReducer from './reducers'
 
-// these modified DSN's are for working with test data. You can ignore them.
-let DSN = process.env.REACT_APP_DSN
-let KEY = DSN.split('@')[0]
-if (KEY.indexOf('s') === 4) {
-  KEY = KEY.replace('s', '') // http vs https
+/* use this if sending events to a proxy and not Sentry */
+function testData(DSN) {
+  let KEY = DSN.split('@')[0]
+  if (KEY.indexOf('s') === 4) {
+    KEY = KEY.replace('s', '') // http vs https
+  }
+  const PROXY = 'localhost:3001'
+  const MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
+  const MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
+  return MODIFIED_DSN_SAVE
 }
-const PROXY = 'localhost:3001'
-const MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
-const MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
-// TODO only use this if you're sending events through a proxy for test data automation
-// DSN = testData(DSN)
+let DSN = testData(process.env.REACT_APP_DSN)
+console.log("> DSN ", DSN)
 
 const tracingOrigins = [
   'localhost', 
@@ -33,7 +35,8 @@ const tracingOrigins = [
 console.log('tracingOrigins', tracingOrigins)
 
 Sentry.init({
-    dsn: process.env.REACT_APP_DSN || 'https://0d52d5f4e8a64f5ab2edce50d88a7626@sentry.io/1428657',
+    dsn: DSN,
+    // dsn: process.env.REACT_APP_DSN || 'https://0d52d5f4e8a64f5ab2edce50d88a7626@sentry.io/1428657',
     release: process.env.REACT_APP_RELEASE,
     environment: "prod",
     debug: true,

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -15,12 +15,13 @@ import rootReducer from './reducers'
 /* use this if sending events to a proxy and not Sentry */
 function testData(DSN) {
   let KEY = DSN.split('@')[0]
-  if (KEY.indexOf('s') === 4) {
-    KEY = KEY.replace('s', '') // http vs https
-  }
+  // if (KEY.indexOf('s') === 4) {
+  //   KEY = KEY.replace('s', '') // http vs https
+  // }
   const PROXY = 'localhost:3001'
   const MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
-  const MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
+  // const MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
+  const MODIFIED_DSN_SAVE = KEY + '@' + "3d19db15b56d.ngrok.io" + '/3'
   return MODIFIED_DSN_SAVE
 }
 let DSN = testData(process.env.REACT_APP_DSN)
@@ -35,8 +36,8 @@ const tracingOrigins = [
 console.log('tracingOrigins', tracingOrigins)
 
 Sentry.init({
-    dsn: DSN,
     // dsn: process.env.REACT_APP_DSN || 'https://0d52d5f4e8a64f5ab2edce50d88a7626@sentry.io/1428657',
+    dsn: DSN,
     release: process.env.REACT_APP_RELEASE,
     environment: "prod",
     debug: true,

--- a/react/src/index.js
+++ b/react/src/index.js
@@ -12,20 +12,20 @@ import { createStore, applyMiddleware } from 'redux'
 import logger from 'redux-logger'
 import rootReducer from './reducers'
 
-/* use this if sending events to a proxy and not Sentry */
+/* use this if sending test data to a proxy and not Sentry 
 function testData(DSN) {
   let KEY = DSN.split('@')[0]
-  // if (KEY.indexOf('s') === 4) {
-  //   KEY = KEY.replace('s', '') // http vs https
-  // }
+  // only for local proxy, not proxy served by ngrok
+  if (KEY.indexOf('https') === 0) {
+    KEY = KEY.replace('s', '')
+  }
   const PROXY = 'localhost:3001'
-  const MODIFIED_DSN_FORWARD = KEY + '@' + PROXY + '/2'
-  // const MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
+  const MODIFIED_DSN_SAVE = KEY + '@' + PROXY + '/3'
   const MODIFIED_DSN_SAVE = KEY + '@' + "3d19db15b56d.ngrok.io" + '/3'
   return MODIFIED_DSN_SAVE
 }
 let DSN = testData(process.env.REACT_APP_DSN)
-console.log("> DSN ", DSN)
+console.log("> DSN ", DSN)*/
 
 const tracingOrigins = [
   'localhost', 
@@ -36,8 +36,7 @@ const tracingOrigins = [
 console.log('tracingOrigins', tracingOrigins)
 
 Sentry.init({
-    // dsn: process.env.REACT_APP_DSN || 'https://0d52d5f4e8a64f5ab2edce50d88a7626@sentry.io/1428657',
-    dsn: DSN,
+    dsn: process.env.REACT_APP_DSN || 'https://0d52d5f4e8a64f5ab2edce50d88a7626@sentry.io/1428657',
     release: process.env.REACT_APP_RELEASE,
     environment: "prod",
     debug: true,


### PR DESCRIPTION
it's according to a [long-tail](https://en.wikipedia.org/wiki/Long_tail) distribution of values for the timeout

## How
`time.sleep(numpy.random.lognormal(0.75, .6, 1)[0])`

## Result
![image](https://user-images.githubusercontent.com/8920574/86671191-428b6a80-bfaa-11ea-8771-9e0b97dc80bc.png)
https://sentry.io/organizations/testorg-az/performance/?project=5260888&project=1428657&query=transaction%3Ahttps%3A%2F%2Fwcap-react-m3uuizd7iq-uc.a.run.app%2F&statsPeriod=7d

## Tested
#### Prod GCP

[js error /checkout ](https://sentry.io/organizations/testorg-az/discover/will-frontend-react:672a80057f2846ba9c72c4b9d9f11eb0/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&project=5260888&project=1428657&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1)

[js tx /checkout](https://sentry.io/organizations/testorg-az/discover/will-frontend-react:cc8b5053050c43638b11f32493f0fdf7/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&project=5260888&project=1428657&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1)

[py tx /checkout](https://sentry.io/organizations/testorg-az/discover/python-test:6c42b4824cc6483a9be57db7d8eaf44e/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&project=5260888&project=1428657&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1)

[py error /checkout](https://sentry.io/organizations/testorg-az/discover/python-test:174693b8358c4f26b7e4f1d94245daa1/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&project=5260888&project=1428657&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1)

[py tx pageload](https://sentry.io/organizations/testorg-az/discover/python-test:db0deba2f5ab48a48fc2663f1b6ee836/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1)

[js tx pageload](https://sentry.io/organizations/testorg-az/discover/will-frontend-react:7e4b337327864ab18f91b3081b74c208/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1)

#### Dev without Docker
[js tx /checkout](https://sentry.io/organizations/testorg-az/discover/will-frontend-react:ebe5db8f0c9e4d588b6ea4ac2fc450f9/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1)

[py error /checkout](https://sentry.io/organizations/testorg-az/discover/python-test:913237422dd749efb5ab433015cea5d9/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1)

[py tx /checkout](https://sentry.io/organizations/testorg-az/discover/python-test:b110a98da9f640b18fe2938043bdedcf/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1)

[py tx pageload](https://sentry.io/organizations/testorg-az/discover/python-test:a3e4e27a105e4c6c96cf1888ef956851/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1)

[js tx /pageload](https://sentry.io/organizations/testorg-az/discover/will-frontend-react:bc6befe5beb44c759d2f7f4a8903e15a/?field=title&field=event.type&field=project&field=user&field=timestamp&name=All+Events&query=&sort=-timestamp&statsPeriod=24h&widths=-1&widths=-1&widths=-1&widths=-1&widths=-1)