### PR TITLE
Adding Release Health to React Project

### DIFF
--- a/react/src/index.js
+++ b/react/src/index.js
@@ -42,6 +42,7 @@ Sentry.init({
       }),
     ],
     tracesSampleRate: 1.0,
+    autoSessionTracking: true,
 });
 
 const sentryReduxEnhancer = Sentry.createReduxEnhancer({});


### PR DESCRIPTION
Adding release health with one line of configuration in` Sentry.init()`

This will begin counting unique users and **new** issues and displaying on release health.
As both the **Flask** and **React** projects are part of the release, issues in either are aggregated within the view.
The **React** project doesn't seem to report errors in the transaction, so its dashboard is pretty dull. 

Issue:
https://sentry.io/organizations/testorg-az/issues/2034825296/?project=5518825&query=is%3Aunresolved

![Screen Shot 2020-12-16 at 12 46 36 PM](https://user-images.githubusercontent.com/3869147/102411450-ceb4ab80-3fa6-11eb-87c0-4f4b74f79f29.png)
![Screen Shot 2020-12-16 at 12 51 09 PM](https://user-images.githubusercontent.com/3869147/102411456-d07e6f00-3fa6-11eb-93da-e22ad94c2640.png)
![Screen Shot 2020-12-16 at 12 52 15 PM](https://user-images.githubusercontent.com/3869147/102411466-d3795f80-3fa6-11eb-8fdb-73b08238c671.png)
